### PR TITLE
Fixes broken bookmarks/other listing.

### DIFF
--- a/_posts/bookmarks/2017-04-22-sheep_cheeses.md
+++ b/_posts/bookmarks/2017-04-22-sheep_cheeses.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sheep Cheeses
-category: other
+category: bookmarks
 ---
 
 * Arpea de Brebis

--- a/category/bookmarks.md
+++ b/category/bookmarks.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: Bookmarks
+category: bookmarks
+---

--- a/category/cheeses.md
+++ b/category/cheeses.md
@@ -1,5 +1,0 @@
----
-layout: post
-title: Cheeses
-category: cheeses
----

--- a/index.md
+++ b/index.md
@@ -35,8 +35,8 @@ title: House Recipes
 
 {% include list.html category="meat" %}
 
-### Bookmarks
+### Other: Bookmarked Favorites, etc.
 
-{% include list.html category="cheeses" %}
+{% include list.html category="bookmarks" %}
 
 


### PR DESCRIPTION
It seems that the other/bookmark category was not being displayed, due
to a confluence of reasons that should now be fixed with the following
changes:
- Fixes dangling references to the 'cheese' category.
- Fixes lack of date in sheep cheese file.
- Consolidates 'other' and 'bookmarks' categories into a single
  'bookmarks' category for posts. This, and other misc. can now go
  into an 'Other' section heading on the index page.

/cc @zmagg